### PR TITLE
Feature: Support time-slot booking.

### DIFF
--- a/src/index.did
+++ b/src/index.did
@@ -1,10 +1,17 @@
 type Booking = record {
   id : int32;
   doctorId : int32;
+  startAt : nat64;
   userId : int32;
   createdAt : nat64;
+  endAt : nat64;
 };
-type BookingPayload = record { doctorId : int32; userId : int32 };
+type BookingPayload = record {
+  doctorId : int32;
+  userId : int32;
+  endSessionAt : nat64;
+  startSessionAt : nat64;
+};
 type Doctor = record { id : int32; username : text; createdAt : nat64 };
 type User = record { id : int32; username : text; createdAt : nat64 };
 service : () -> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -207,28 +207,27 @@ export function createBooking(payload: BookingPayload): Booking {
     }
 
     const now = ic.time();
-    // Time slot is valid ?
-    if(startAt <= now || startAt <= now) {
+    if(startAt <= now || startAt <= now || startAt >= endAt) {
         throw new Error("startAt or endAt with the given time is invalid (passed)");
     }
 
     // Time slot = [startSession:endSession]
     // Check Doctor and User available ?
     
-    // bookings.startSession < booking.startSession && booking.endSession < bookings.endSession
-    //  [---bookings---]
+    // booking.startSession <= startAt && endAt < booking.endSession
+    //  [---booking---]
     //    |         | 
-    //    [ booking ]
+    //   s[ payload ]e
 
-    // bookings.endSession > booking.startSession 
-    //  [---bookings---]
-    //                 |
-    //             [--- * booking]
+    // booking.endSession >= startAt
+    //  [---booking---]
+    //                |
+    //             s[--- * payload]e
 
-    // bookings.startSession > booking.startSession && booking.endSession < bookings.startSession
-    //         [---bookings---]
+    // booking.startSession >= startAt && endAt >= booking.startSession
+    //         [---booking---]
     //         |
-    //     [booking --- * ]
+    //     s[payload --- * ]e
 
     // 1694397929150744000 - 1694399929150744000
 
@@ -238,20 +237,11 @@ export function createBooking(payload: BookingPayload): Booking {
             booking => ((booking.userId === userId || booking.doctorId === doctorId) && 
                             ((booking.startAt <= startAt && endAt <= booking.endAt) ||
                              (booking.endAt >= startAt) ||
-                             (booking.startAt >= startAt && endAt <= booking.startAt)))
-            ));
+                             (booking.startAt >= startAt && endAt >= booking.startAt)))
+        ));
     if (checkBooking) {
         throw new Error("A session has already been booked!");
     }
-
-    // // Check for existing booking
-    // const checkBooking = bookings.values().find(
-    //     (
-    //         booking => booking.userId === userId && booking.doctorId === doctorId
-    //         ));
-    // if (checkBooking) {
-    //     throw new Error("A session has already been booked!");
-    // }
 
     // Create new booking record
     try {


### PR DESCRIPTION
Add a time slot to the Booking Record and check if the time slot is available for the user and doctor.

This pull request addresses the need to incorporate a time slot feature into the Booking Record. This enhancement will allow users to schedule appointments with doctors based on specific time slots.

Here are the key changes made in this pull request:

* Addition of Time Slot to Booking Record: We've introduced a new field in the Booking Record called startAt, endAt. This field will store the designated time for the appointment.

* Availability Check for User and Doctor: To ensure that the chosen time slot is available, we've implemented a check. This verification process involves examining the schedules of both the user and the doctor involved in the booking.

By incorporating these changes, we aim to enhance the user experience by providing a more intuitive and efficient booking process. Users can now select a suitable time slot with confidence, knowing that it aligns with both their own schedule and the availability of the designated doctor.
